### PR TITLE
using ExternalOrderId instead of OrderId to identify execution order …

### DIFF
--- a/src/MarginTrading.TradingHistory.SqlRepositories/OrdersHistorySqlRepository.cs
+++ b/src/MarginTrading.TradingHistory.SqlRepositories/OrdersHistorySqlRepository.cs
@@ -48,7 +48,7 @@ OUTER APPLY (
     Spread = (
       SELECT TOP 1 Spread
       FROM dbo.ExecutionOrderBooks AS eob WITH (NOLOCK)
-      WHERE eob.OrderId = history.Id
+      WHERE eob.ExternalOrderId = history.ExternalOrderId
     )
 ) AS Spread
 OUTER APPLY (


### PR DESCRIPTION
…book in ExecutionOrderBooks table